### PR TITLE
# Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 4.2.1
+
+### Improvements
+- Hide fullscreen icon of iFrame
+
+### Bugfix
+- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
+- UI differs if deployed via Appstudio or VS Code AppSpace SDK
+
 ## Release 4.2.0
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
 - UI differs if deployed via Appstudio or VS Code AppSpace SDK
 - Fullscreen icon of iFrame was visible
+- Status change of "Internal log handling" was not logged
 
 ## Release 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## Release 4.2.1
 
-### Improvements
-- Hide fullscreen icon of iFrame
-
 ### Bugfix
 - Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
 - UI differs if deployed via Appstudio or VS Code AppSpace SDK
+- Fullscreen icon of iFrame was visible
 
 ## Release 4.2.0
 

--- a/CSK_1stModule_Logger/pages/pages/CSK_Module_Logger/CSK_Module_Logger.css
+++ b/CSK_1stModule_Logger/pages/pages/CSK_Module_Logger/CSK_Module_Logger.css
@@ -87,5 +87,5 @@
 
 .myCustomButton_CSK_Module_Logger {
   border-radius: 30px;
-  padding-right: 0px;
+  padding: 11px;
 }

--- a/CSK_1stModule_Logger/pages/pages/CSK_Module_Logger/CSK_Module_Logger.html
+++ b/CSK_1stModule_Logger/pages/pages/CSK_Module_Logger/CSK_Module_Logger.html
@@ -5,12 +5,12 @@
         <layout-row id="RowLayout15">
             <layout-column id="ColumnLayout17" style="align-items: stretch">
                 <layout-row id="RowLayout13" style="align-items: baseline">
-                    <davinci-value-display id="V_Title" class="myCustomLabel_CSK_Module_Logger" value="Logger">
-                    </davinci-value-display>
+                    <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_Logger">
+                        Logger
+                    </h1>
                     <davinci-value-display id="VD_Version">
-                        <crown-edpws-binding property="value" name="CSK_Logger/OnNewStatusModuleVersion"
-                            update-on-resume>
-                        </crown-edpws-binding>
+                        <crown-on property="value" crown-event="CSK_Logger/OnNewStatusModuleVersion">
+                        </crown-on>
                     </davinci-value-display>
                 </layout-row>
             </layout-column>
@@ -62,9 +62,10 @@
                                                                     style="justify-content: center; align-items: center">
                                                                     <davinci-button id="B_LoadConfig"
                                                                         class="myCustomButton_CSK_Module_Logger"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Load configured parameters from CSK_PersistentData module."
-                                                                        icon="action/history">
+                                                                        type="outline"
+                                                                        title="Load configured parameters from CSK_PersistentData module.">
+                                                                        <davinci-icon icon="action/history">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_Logger/loadParameters"
@@ -78,9 +79,10 @@
                                                                     </davinci-button>
                                                                     <davinci-button id="B_SaveConfig"
                                                                         class="myCustomButton_CSK_Module_Logger"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Save current configured parameters of this module within CSK_PersistentData module."
-                                                                        icon="content/save">
+                                                                        type="outline"
+                                                                        title="Save current configured parameters of this module within CSK_PersistentData module.">
+                                                                        <davinci-icon icon="content/save">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_Logger/sendParameters"
@@ -388,9 +390,8 @@
                                     <layout-column id="ColumnLayout21" style="align-items: stretch">
                                         <davinci-text-area id="TA_LogEntries" class="myMinHeight500px_CSK_Module_Logger"
                                             label="Log messages">
-                                            <crown-edpws-binding property="value" name="CSK_Logger/OnNewCompleteLogfile"
-                                                update-on-resume>
-                                            </crown-edpws-binding>
+                                            <crown-on property="value" crown-event="CSK_Logger/OnNewCompleteLogfile">
+                                            </crown-on>
                                         </davinci-text-area>
                                         <stacked-view id="SV_SinkActive">
                                             <stacked-pane id="SP_SinkActive" value="true">
@@ -410,8 +411,9 @@
                                                     </appspace-file-download-button>
                                                     <davinci-button id="Button_ReloadLog"
                                                         class="myCustomButton_CSK_Module_Logger" type="outline"
-                                                        icon-position="append" icon="navigation/refresh"
                                                         title="Reload Logfile">
+                                                        <davinci-icon icon="navigation/refresh">
+                                                        </davinci-icon>
                                                         <span></span>
                                                         <crown-binding event="submit" name="CSK_Logger/reloadLogsInUI"
                                                             auto-commit>

--- a/CSK_1stModule_Logger/pages/src/converter.ts
+++ b/CSK_1stModule_Logger/pages/src/converter.ts
@@ -1,6 +1,14 @@
 export function changeStyle(theme) {
   const style: HTMLStyleElement = document.createElement('style');
   style.id ='blub'
+
+  const toggleSW = document.querySelectorAll("davinci-toggle-switch")
+  toggleSW.forEach((userItem) => {
+    const shadowToggle = userItem.shadowRoot
+    const finalToggleSW = shadowToggle?.querySelector('div')
+    finalToggleSW?.classList.add('hasIcon')
+  });
+
   if (theme == 'CSK_Style'){
     var headerToolbar = `.sopasjs-ui-header-toolbar-wrapper { background-color: #FFFFFF; }`
     var uiHeader = `.sopasjs-ui-header>.app-logo { margin-right:0px; }`

--- a/CSK_1stModule_Logger/pages/src/index.ts
+++ b/CSK_1stModule_Logger/pages/src/index.ts
@@ -1,7 +1,7 @@
 document.addEventListener('sopasjs-ready', () => {
-const page_1 = document.querySelector('div.sopasjs-ui-navbar-wrapper > div > ul > li:nth-child(3) > a > i');
-page_1.classList.remove('fa-file');
-page_1.classList.add('fa-comment-o');
+  const page_1 = document.querySelector('div.sopasjs-ui-navbar-wrapper > div > ul > li:nth-child(3) > a > i');
+  page_1.classList.remove('fa-file');
+  page_1.classList.add('fa-comment-o');
 
   const page_FirstLabel = document.querySelector('div.sopasjs-ui-navbar-wrapper > div > ul > li:nth-child(2)');
   const page_App = document.querySelector('div.sopasjs-ui-navbar-wrapper > div > ul > li:nth-child(4)');
@@ -12,6 +12,10 @@ page_1.classList.add('fa-comment-o');
   page_Setup.remove();
 
   setTimeout(() => {
+    const element = document.querySelector("div.sjs-wrapper > div > div.sjs-fullscreen-toggle")
+    if(element) {
+      element.parentElement.removeChild(element)
+    }
     document.title = 'CSK_Module_Logger'
-}, 500);
+  }, 500);
 })

--- a/CSK_1stModule_Logger/project.mf.xml
+++ b/CSK_1stModule_Logger/project.mf.xml
@@ -181,7 +181,7 @@ Check UI of this module for most available features. +
             </serves>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">4.2.0</meta>
+        <meta key="version">4.2.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_1stModule_Logger/scripts/Communication/Logger/Logger_Controller.lua
+++ b/CSK_1stModule_Logger/scripts/Communication/Logger/Logger_Controller.lua
@@ -213,6 +213,7 @@ Script.serveFunction('CSK_Logger.setLogFileSize', setLogFileSize)
 
 local function setCallbackSinkActive(status)
   _G.logger:fine(nameOfModule .. ': Set status of callBackSink to ' .. tostring(status))
+  logger_Model.loggerCallback(nameOfModule .. ': Set status of callBackSink to ' .. tostring(status), nil, 'FINE')
   logger_Model.parameters.callBackSink = status
   logger_Model.setupLogHandler()
   handleOnExpiredTmrLogger()

--- a/CSK_1stModule_Logger/scripts/Communication/Logger/Logger_Model.lua
+++ b/CSK_1stModule_Logger/scripts/Communication/Logger/Logger_Model.lua
@@ -109,6 +109,7 @@ local function loggerCallback(message, path, level, timestamp, appName, appPosit
 
   sendLog()
 end
+logger_Model.loggerCallback = loggerCallback
 
 --- Function to setup the logger
 local function setupLogHandler()

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ For further information check out the [documentation](https://raw.githack.com/SI
 Tested on:  
 |Device|Firmware|Module version|
 |--|--|--|
-|SICK AppEngine|V1.7.0|V4.2.0|
+|SIM1012|V2.4.2|V4.2.1|
 |SIM1012|V2.4.2|V4.2.0|
+|SICK AppEngine|V1.7.0|V4.2.0|
 |SICK AppEngine|V1.3.2|<V4.2.0|
 |SIM1012|V2.2.0|<V4.2.0|
 

--- a/docu/CSK_1stModule_Logger.html
+++ b/docu/CSK_1stModule_Logger.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_1stModule_Logger 4.2.0</title>
+<title>Documentation - CSK_1stModule_Logger 4.2.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_1stModule_Logger 4.2.0</h1>
+<h1>Documentation - CSK_1stModule_Logger 4.2.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 4.2.0,</span>
+<span id="revnumber">version 4.2.1,</span>
 <span id="revdate">2024-07-31</span>
 </div>
 <div id="toc" class="toc2">
@@ -710,7 +710,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">4.2.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.2.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -2690,7 +2690,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 4.2.0<br>
+Version 4.2.1<br>
 Last updated 2024-07-31 16:11:45 +0200
 </div>
 </div>


### PR DESCRIPTION
# Release 4.2.1

## Bugfix
- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
- UI differs if deployed via Appstudio or VS Code AppSpace SDK
- Fullscreen icon of iFrame was visible
- Status change of "Internal log handling" was not logged

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
